### PR TITLE
Logging of the integer value of the enum

### DIFF
--- a/src/EnumLogger/Extensions/EnumLogger.cs
+++ b/src/EnumLogger/Extensions/EnumLogger.cs
@@ -67,7 +67,7 @@ namespace EnumLogger.Extensions
                 : LogManager.GetLogger(callingClass.GetType());
 
             var enumValue = Convert.ChangeType(logEvent, logEvent.GetType());
-            MDC.Set(EventId, enumValue.ToString());
+            MDC.Set(EventId, ((int)enumValue).ToString());
             var enumName = logEvent.GetName();
             MDC.Set(EventName, enumName);
             var logMessage = string.IsNullOrEmpty(message) ? enumName : string.Join(": ", enumName, message);


### PR DESCRIPTION
This fixes the duplicated logging of the enum name, whilst a logging of the enum integer id is the desired behaviour.

Previously:
`ERROR ASP.global_asax: AppStart: App started {EventId=AppStart, EventName=AppStart}`

Fixed:
`ERROR ASP.global_asax: AppStart: App started {EventId=1001, EventName=AppStart}`